### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3](https://github.com/simonsan/cargo-rhack/compare/v0.1.2...v0.1.3) - 2024-03-17
+
+### Fixed
+- deny config
+- config
+- clippy lints
+
+### Other
+- fix missing version in msrv test
+- update fixtures
+- fix workspace patching test
+- fix env var
+- add cargo deny config
+- update msrv
+- update dependencies
+- update manifest
+- maintenance
+
 ## 0.1.2 (2023-05-21)
 
 <csr-id-bc2239651306548bc3432e42691e655f54ef6d28/>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "cargo-rhack"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-rhack"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["nakabonne <ryo@nakao.dev>"]
 categories = ["command-line-utilities"]
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `cargo-rhack`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/simonsan/cargo-rhack/compare/v0.1.2...v0.1.3) - 2024-03-17

### Fixed
- deny config
- config
- clippy lints

### Other
- fix missing version in msrv test
- update fixtures
- fix workspace patching test
- fix env var
- add cargo deny config
- update msrv
- update dependencies
- update manifest
- maintenance
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).