### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5](https://github.com/simonsan/cargo-rhack/compare/v0.1.4...v0.1.5) - 2024-03-17
+
+### Other
+- update manifest
+- fix description
+- update authors in manifest
+- update license with original BSD 3-Clause template
+- update description
+- update scoop manifest
+
 ## [0.1.4](https://github.com/simonsan/cargo-rhack/compare/v0.1.3...v0.1.4) - 2024-03-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "cargo-rhack"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-rhack"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["the cargo-rhack team"]
 categories = ["command-line-utilities"]
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `cargo-rhack`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/simonsan/cargo-rhack/compare/v0.1.4...v0.1.5) - 2024-03-17

### Other
- update manifest
- fix description
- update authors in manifest
- update license with original BSD 3-Clause template
- update description
- update scoop manifest
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).