### PR TITLE
feature: allow reading `RHACK_DIR` from `.cargo/config.toml` files.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+
+[env]
+RHACK_DIR = "./.rhack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ pr-run-mode = "plan"
 # see: https://nnethercote.github.io/perf-book/build-configuration.html
 [profile.dev]
 opt-level = 0
-debug = 0 # try for faster builds, usually 'true'
-strip = "debuginfo" # try for faster builds
+debug = 0               # try for faster builds, usually 'true'
+strip = "debuginfo"     # try for faster builds
 rpath = false
 lto = false
 debug-assertions = true
@@ -71,7 +71,7 @@ debug = true
 
 [profile.release]
 opt-level = 3
-debug = false # true for profiling
+debug = false            # true for profiling
 rpath = false
 lto = "fat"
 debug-assertions = false
@@ -89,7 +89,7 @@ codegen-units = 4
 
 [profile.bench]
 opt-level = 3
-debug = true # true for profiling
+debug = true             # true for profiling
 rpath = false
 lto = true
 debug-assertions = false


### PR DESCRIPTION
Search order: 

1. `$RHACK_DIR`
2. `.cargo/config.toml`
3. `$CARGO_HOME/config.toml`

